### PR TITLE
PHP7 Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@ All notable changes to this project will be documented in this file.
 - Some code documentation
 
 ### Fixed
+- PHP7 bug: No boolean return values of open() and close()
+- PHP7 bug: Data serialization in write()
 - Check for existing Predis Client instance before invoking it (caused NOTICE)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change log
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Some code documentation
+
+### Fixed
+- Check for existing Predis Client instance before invoking it (caused NOTICE)

--- a/_config.php
+++ b/_config.php
@@ -1,6 +1,6 @@
 <?php
 
 // Include the Composer autoloader.
-require_once __DIR__ . '/../vendor/autoload.php';
+//require_once __DIR__ . '/../vendor/autoload.php';
 
 $databaseSessionHandler = new SilverStripe\Predis\RedisSessionHandler();

--- a/src/SilverStripe/Predis/RedisSessionHandler.php
+++ b/src/SilverStripe/Predis/RedisSessionHandler.php
@@ -13,8 +13,7 @@ namespace SilverStripe\Predis;
 
 use Predis\Client;
 
-class RedisSessionHandler
-{
+class RedisSessionHandler {
 
     public $client;
 
@@ -26,54 +25,61 @@ class RedisSessionHandler
 
     public $key_sep = ':';
 
-    public function __construct($path = 'sessions', $prefix = 'PHPSESSID', $key_sep = ':')
-    {
+    public function __construct($path = 'sessions', $prefix = 'PHPSESSID', $key_sep = ':') {
         $this->client = new Client();
-        $this->ttl    = ini_get('session.gc_maxlifetime');
+        $this->ttl = ini_get('session.gc_maxlifetime');
 
-        $this->path    = $path;
-        $this->prefix  = $prefix;
+        $this->path = $path;
+        $this->prefix = $prefix;
         $this->key_sep = $key_sep;
 
         session_set_save_handler(
-            [$this, "open"],
-            [$this, "close"],
-            [$this, "read"],
-            [$this, "write"],
-            [$this, "destroy"],
-            [$this, "gc"]
+            array($this, "open"),
+            array($this, "close"),
+            array($this, "read"),
+            array($this, "write"),
+            array($this, "destroy"),
+            array($this, "gc")
         );
     }
 
-    function redisKeyPath()
-    {
+    /**
+     * Returns the full key path which Redis uses.
+     *
+     * @return string
+     */
+    private function redisKeyPath() {
         return $this->path . $this->key_sep . $this->prefix . $this->key_sep;
     }
 
     /**
-     * No action necessary because connection is injected
-     * in constructor and arguments are not applicable.
+     * No action necessary because connection is injected in constructor and arguments are not applicable.
+     *
+     * @param $savePath
+     * @param $sessionName
      */
-    public function open($savePath, $sessionName)
-    {
+    public function open($savePath, $sessionName) { }
 
-    }
-
-    public function close()
-    {
+    /**
+     * Clears the Predis Client.
+     */
+    public function close() {
         $this->client = null;
         unset($this->client);
     }
 
     /**
-     * Gets json_encoded Session data from Redis
-     * and encode it back to php's session encoding
+     * Gets json_encoded Session data from Redis and encode it back to php's session encoding.
+     *
+     * @param $id
+     *
+     * @return string
      */
-    public function read($id)
-    {
+    public function read($id) {
+        if (!$this->client) return null;
 
         $tmp = $_SESSION;
-        $id  = $this->redisKeyPath() . $id;
+        $id = $this->redisKeyPath() . $id;
 
         $_SESSION = json_decode($this->client->get($id), true);
         $this->client->expire($id, $this->ttl);
@@ -81,6 +87,7 @@ class RedisSessionHandler
         if (isset($_SESSION) && !empty($_SESSION) && $_SESSION != null) {
             $new_data = session_encode();
             $_SESSION = $tmp;
+
             return $new_data;
         } else {
             return "";
@@ -88,31 +95,44 @@ class RedisSessionHandler
     }
 
     /**
-     * Writes Session json_encoded, so we can access the Session data with other clients like node.js
+     * Writes Session json_encoded, so we can access the Session data also with other clients (like node.js)
+     *
+     * @param $id Session ID
+     * @param $data Payload data.
+     *
+     * @return bool
      */
-    public function write($id, $data)
-    {
+    public function write($id, $data) {
+        if (!$this->client) return false;
+
+        // Write payload data to session
         $tmp = $_SESSION;
         session_decode($data);
         $new_data = $_SESSION;
         $_SESSION = $tmp;
 
+        // Write payload to Redis and set expiration
         $id = $this->redisKeyPath() . $id;
         $this->client->set($id, json_encode($new_data));
         $this->client->expire($id, $this->ttl);
+
         return true;
     }
 
-    public function destroy($id)
-    {
-        $this->client->del($this->redisKeyPath() . $id);
+    /**
+     * Deletes a session by ID.
+     *
+     * @param $id Session ID
+     */
+    public function destroy($id) {
+        if ($this->client)
+            $this->client->del($this->redisKeyPath() . $id);
     }
 
     /**
      * No need to gc because of using expiration
+     *
+     * @param $maxLifetime
      */
-    public function gc($maxLifetime)
-    {
-
-    }
+    public function gc($maxLifetime) { }
 }

--- a/src/SilverStripe/Predis/RedisSessionHelper.php
+++ b/src/SilverStripe/Predis/RedisSessionHelper.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Helper class taken from: http://php.net/manual/en/function.session-decode.php#108037
+ */
+namespace SilverStripe\Predis;
+
+class RedisSessionHelper {
+
+    public static function unserialize($session_data) {
+        $method = ini_get("session.serialize_handler");
+        switch ($method) {
+            case "php":
+                return self::unserialize_php($session_data);
+                break;
+            case "php_binary":
+                return self::unserialize_phpbinary($session_data);
+                break;
+            default:
+                throw new Exception("Unsupported session.serialize_handler: " . $method . ". Supported: php, php_binary");
+        }
+    }
+
+    private static function unserialize_php($session_data) {
+        $return_data = array();
+        $offset = 0;
+        while ($offset < strlen($session_data)) {
+            if (!strstr(substr($session_data, $offset), "|")) {
+                throw new Exception("invalid data, remaining: " . substr($session_data, $offset));
+            }
+            $pos = strpos($session_data, "|", $offset);
+            $num = $pos - $offset;
+            $varname = substr($session_data, $offset, $num);
+            $offset += $num + 1;
+            $data = unserialize(substr($session_data, $offset));
+            $return_data[$varname] = $data;
+            $offset += strlen(serialize($data));
+        }
+
+        return $return_data;
+    }
+
+    private static function unserialize_phpbinary($session_data) {
+        $return_data = array();
+        $offset = 0;
+        while ($offset < strlen($session_data)) {
+            $num = ord($session_data[$offset]);
+            $offset += 1;
+            $varname = substr($session_data, $offset, $num);
+            $offset += $num;
+            $data = unserialize(substr($session_data, $offset));
+            $return_data[$varname] = $data;
+            $offset += strlen(serialize($data));
+        }
+
+        return $return_data;
+    }
+}


### PR DESCRIPTION
There were two issues when using the session handler with PHP7:
- Data serialization in write()
- No boolean return values of open() and close()

I've added a helper class for session data serialization and added the return values. Tested with PHP5.6 and PHP7.0.